### PR TITLE
adds basic package.json to enable npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "aws-github-to-s3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "balanced-match": {
       "version": "1.0.0",


### PR DESCRIPTION
This will allow people to clone this repository and run `npm install` to install the `serverless-python-requirements` Serverless plugin.