### PR TITLE
removes warm container /tmp contents

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -39,12 +39,16 @@ def lambda_handler(event, context):
 
     repo_path = '/tmp/%s' % full_name
 
+    try:
+        shutil.rmtree(repo_path)
+        os.remove(zipfile)
+    except:
+        print('Nothing to remove')
+        pass
+
     clone_repository(repo_url, repo_path, checkout_branch=repo_branch)
     zipfile = zip_repo(repo_path, full_name)
     push_s3(zipfile, full_name, outputbucket)
-
-    shutil.rmtree(repo_path)
-    os.remove(zipfile)
 
     return 'Successfully updated %s' % full_name
 


### PR DESCRIPTION
A warm container will still have content previously written to `/tmp`:

>Let’s say your function finishes, and some time passes, then you call it again. Lambda may create a new container all over again, in which case the experience is just as described above. This will be the case for certain if you change your code.
>
>However, if you haven’t changed the code and not too much time has gone by, Lambda may reuse the previous container. This offers some performance advantages to both parties: Lambda gets to skip the nodejs language initialization, and you get to skip initialization in your code. Files that you wrote to /tmp last time around will still be there if the sandbox gets reused.

https://aws.amazon.com/blogs/compute/container-reuse-in-lambda/

This PR addresses that issue by clearing out a previously cloned repository before cloning again.