### PR TITLE
Fixes #13 by adding OutputBucket export

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -250,3 +250,9 @@ resources:
         Variables:
           outputbucket:
             Ref: OutputBucket
+  Outputs:
+    OutputBucketExport:
+      Value:
+        Ref: OutputBucket
+      Export:
+        Name: github-to-s3-outputbucket


### PR DESCRIPTION
I have tested this in an account and validated that the stack export is created. We should be able to use the following in our other stack references:

`Export name: github-to-s3-outputbucket`